### PR TITLE
perf: stream DA SSE updates as each RPC call completes

### DIFF
--- a/backend/crates/atlas-server/src/indexer/da_worker.rs
+++ b/backend/crates/atlas-server/src/indexer/da_worker.rs
@@ -137,7 +137,9 @@ impl DaWorker {
         let client = &self.client;
         let rate_limiter = &self.rate_limiter;
 
-        let results: Vec<Option<DaSseUpdate>> = stream::iter(blocks)
+        let mut total_updated = 0usize;
+
+        stream::iter(blocks)
             .map(|(block_number,)| async move {
                 rate_limiter.until_ready().await;
                 match client.get_da_status(block_number as u64).await {
@@ -176,13 +178,16 @@ impl DaWorker {
                 }
             })
             .buffer_unordered(self.concurrency)
-            .collect()
+            .for_each(|result| {
+                if let Some(update) = result {
+                    total_updated += 1;
+                    self.notify_da_updates(std::slice::from_ref(&update));
+                }
+                std::future::ready(())
+            })
             .await;
 
-        let updates: Vec<DaSseUpdate> = results.into_iter().flatten().collect();
-        self.notify_da_updates(&updates);
-
-        Ok(updates.len())
+        Ok(total_updated)
     }
 }
 


### PR DESCRIPTION
## Summary

- DA SSE updates are now broadcast immediately as each ev-node RPC call returns, rather than waiting for the entire batch to finish
- Previously, SSE clients waited for the slowest of 100 concurrent RPC calls before receiving any update; now the first result appears as soon as the fastest call in the batch completes
- Change is a one-line swap: `.collect().await` + end-of-batch `notify_da_updates` → `.for_each` that calls `notify_da_updates` per result

## Test plan

- [ ] All existing unit and integration tests pass (`cargo test --workspace`)
- [ ] Clippy clean (`cargo clippy --workspace -- -D warnings`)
- [ ] Verify in staging that DA status columns on the blocks page populate progressively rather than all at once

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized data availability worker to process block updates more efficiently with improved notification handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->