### PR TITLE
fix: proxy /api to backend for eth_getBalance

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -40,4 +40,12 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
+
+    # Etherscan-compatible API (exact /api path with query params, no trailing slash)
+    location = /api {
+        proxy_pass http://atlas-server:3000/api;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
 }


### PR DESCRIPTION
## Summary

- `getEthBalance` calls `GET /api?module=account&action=balance&address=...` (no trailing slash)
- nginx only had `location /api/` which doesn't match `/api` — the request fell through to the SPA catch-all, returning `index.html` instead of proxying to the backend
- Add `location = /api` exact-match block to proxy the Etherscan-compatible endpoint correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved API request routing to ensure proper handling of API endpoints without trailing slashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->