### PR TITLE
fix: local dev setup for running backend outside Docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,11 @@
 # POSTGRES_USER=atlas
 # POSTGRES_PASSWORD=atlas
 
+# PostgreSQL connection string.
+# When running the full Docker stack: set automatically by docker-compose (do not set here).
+# When running the backend locally against a local or Docker Postgres:
+# DATABASE_URL=postgres://atlas:atlas@localhost:5432/atlas
+
 # Required: Your L2 RPC endpoint
 RPC_URL=http://localhost:8545
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ just frontend-install
 Start the backend:
 
 ```bash
-just backend-server
+just backend-run
 ```
 
 Start frontend:
@@ -59,7 +59,7 @@ Copy `.env.example` to `.env` and set `RPC_URL`. Common options:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `RPC_URL` | Ethereum JSON-RPC endpoint | Required |
-| `DATABASE_URL` | PostgreSQL connection string | Set in docker-compose |
+| `DATABASE_URL` | PostgreSQL connection string | `postgres://atlas:atlas@localhost:5432/atlas` (local dev) |
 | `START_BLOCK` | Block to start indexing from | `0` |
 | `BATCH_SIZE` | Blocks per indexing batch | `100` |
 | `RPC_REQUESTS_PER_SECOND` | RPC rate limit | `100` |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   postgres:
     image: postgres:16-alpine
+    ports:
+      - "5432:5432"
     environment:
       POSTGRES_DB: atlas
       POSTGRES_USER: ${POSTGRES_USER:-atlas}


### PR DESCRIPTION
## Summary
Expose Postgres port 5432 to the host in `docker-compose.yml`, document `DATABASE_URL` in `.env.example` for local dev, and fix the wrong `just backend-server` command in `README.md` (should be `just backend-run`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backend startup instructions with clarified command reference
  * Added example PostgreSQL connection configuration for local development

* **Chores**
  * Configured PostgreSQL to be externally accessible during local development

<!-- end of auto-generated comment: release notes by coderabbit.ai -->