### PR TITLE
fix: add User-Agent to MetadataFetcher HTTP client to prevent CDN 403s

### DIFF
--- a/backend/crates/atlas-server/src/indexer/metadata.rs
+++ b/backend/crates/atlas-server/src/indexer/metadata.rs
@@ -46,6 +46,7 @@ impl MetadataFetcher {
     pub fn new(pool: PgPool, config: Config, metrics: Metrics) -> Result<Self> {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(30))
+            .user_agent("atlas-server/0.1.0")
             .build()
             .expect("Failed to create HTTP client");
 

--- a/backend/crates/atlas-server/src/main.rs
+++ b/backend/crates/atlas-server/src/main.rs
@@ -117,10 +117,8 @@ pub(crate) fn postgres_connection_config(db_url: &str) -> Result<PostgresConnect
 
     for (key, value) in url.query_pairs() {
         match key.as_ref() {
-            "dbname" => {
-                if !value.is_empty() {
-                    database_name = value.into_owned();
-                }
+            "dbname" if !value.is_empty() => {
+                database_name = value.into_owned();
             }
             "host" => {
                 set_pg_env(&mut env_vars, "PGHOST", value.as_ref());


### PR DESCRIPTION
## Summary
Adds `.user_agent("atlas-server/0.1.0")` to the `reqwest` client in `MetadataFetcher::new`. CDNs serving NFT metadata (IPFS gateways, OpenSea, etc.) classify requests with no User-Agent as bots and return 403, causing `image_url` to stay null and images to be blank.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced HTTP request header configuration for improved standards compliance
  * Optimized database connection parameter validation logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->