### PR TITLE
fix: remove token_uri image fallback in NFT pages

### DIFF
--- a/frontend/src/pages/AddressPage.tsx
+++ b/frontend/src/pages/AddressPage.tsx
@@ -332,7 +332,7 @@ export default function AddressPage() {
             <>
               <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
                 {nfts.map((t) => {
-                  const imageUrl = t.image_url || t.token_uri || null;
+                  const imageUrl = t.image_url || null;
                   const displayName = t.name || `#${t.token_id}`;
                   return (
                     <Link key={`${t.contract_address}-${t.token_id}`} to={`/nfts/${t.contract_address}/${t.token_id}`} className="block group">

--- a/frontend/src/pages/NFTContractPage.tsx
+++ b/frontend/src/pages/NFTContractPage.tsx
@@ -82,7 +82,7 @@ export default function NFTContractPage() {
           <div className="card">
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 min-h-[200px]">
               {tokens.map((token) => {
-                const imageUrl = token.image_url || token.token_uri || null;
+                const imageUrl = token.image_url || null;
                 const displayName = token.name || `${contract?.name || contract?.symbol || 'NFT'} #${token.token_id}`;
                 return (
                   <Link

--- a/frontend/src/pages/NFTTokenPage.tsx
+++ b/frontend/src/pages/NFTTokenPage.tsx
@@ -13,7 +13,7 @@ export default function NFTTokenPage() {
   const [txPage, setTxPage] = useState(1);
   const { transfers, pagination, loading } = useNftTokenTransfers(contractAddress, tokenId, { page: txPage, limit: 20 });
 
-  const imageUrl = token?.image_url || token?.token_uri || null;
+  const imageUrl = token?.image_url || null;
   const displayName = token?.name || `${contract?.name || contract?.symbol || 'NFT'} #${token?.token_id || tokenId || ''}`;
 
   return (


### PR DESCRIPTION
## Summary
Remove `token_uri` as image URL fallback in `NFTTokenPage`, `NFTContractPage`, and `AddressPage`. `token_uri` points to JSON metadata, not images — the fallback causes broken image icons. The backend already stores direct image URLs as `image_url`, so the fallback was never useful.

Closes #67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified NFT image display logic across card views. NFTs without primary images will now consistently show a placeholder instead of attempting alternative image sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->