### PR TITLE
fix: use live-dot class for DA pulse animation in BlocksPage

### DIFF
--- a/frontend/src/pages/BlocksPage.tsx
+++ b/frontend/src/pages/BlocksPage.tsx
@@ -531,9 +531,9 @@ export default function BlocksPage() {
                     return (
                       <td className="table-cell text-center">
                         {included ? (
-                          <span className={`w-2 h-2 rounded-full bg-green-400 inline-block${flash ? ' animate-da-pulse' : ''}`} title={includedTitle} />
+                          <span className={`w-2 h-2 rounded-full bg-green-400 inline-block${flash ? ' live-dot' : ''}`} title={includedTitle} />
                         ) : (
-                          <span className={`w-2 h-2 rounded-full bg-yellow-400 inline-block${flash ? ' animate-da-pulse' : ''}`} title="Pending DA inclusion" />
+                          <span className={`w-2 h-2 rounded-full bg-yellow-400 inline-block${flash ? ' live-dot' : ''}`} title="Pending DA inclusion" />
                         )}
                       </td>
                     );


### PR DESCRIPTION
## Summary
Replace `animate-da-pulse` with `live-dot` CSS class for the DA status indicator flash animation in BlocksPage, aligning with the existing class used elsewhere in the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual styling of the Data Availability status indicator, refreshing the appearance for both included and pending states while maintaining the existing dot design and tooltip information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->