### PR TITLE
feat: add NFT token name search to global search bar

### DIFF
--- a/backend/crates/atlas-server/src/api/handlers/search.rs
+++ b/backend/crates/atlas-server/src/api/handlers/search.rs
@@ -14,6 +14,14 @@ pub struct SearchQuery {
     pub q: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct NftTokenResult {
+    pub contract_address: String,
+    pub token_id: String,
+    pub name: Option<String>,
+    pub image_url: Option<String>,
+}
+
 #[derive(Serialize)]
 #[serde(tag = "type")]
 pub enum SearchResult {
@@ -25,6 +33,8 @@ pub enum SearchResult {
     Address(Address),
     #[serde(rename = "nft_collection")]
     NftCollection(NftContract),
+    #[serde(rename = "nft")]
+    Nft(NftTokenResult),
     #[serde(rename = "erc20_token")]
     Erc20Token(Erc20Contract),
 }
@@ -93,14 +103,18 @@ pub async fn search(
 
     // Text search for tokens/collections if no hex/number results and query is meaningful
     if results.is_empty() && query.len() >= 2 {
-        // Run NFT and ERC-20 searches in parallel
-        let (nft_results, erc20_results) = tokio::join!(
+        // Run NFT collection, NFT token, and ERC-20 searches in parallel
+        let (nft_collection_results, nft_token_results, erc20_results) = tokio::join!(
             search_nft_collections(&state, query),
+            search_nft_tokens(&state, query),
             search_erc20_tokens(&state, query)
         );
 
-        for nft in nft_results? {
+        for nft in nft_collection_results? {
             results.push(SearchResult::NftCollection(nft));
+        }
+        for token in nft_token_results? {
+            results.push(SearchResult::Nft(token));
         }
         for token in erc20_results? {
             results.push(SearchResult::Erc20Token(token));
@@ -186,6 +200,24 @@ async fn search_nft_collections(
          WHERE name ILIKE $1 OR symbol ILIKE $1
          ORDER BY total_supply DESC NULLS LAST
          LIMIT 10",
+    )
+    .bind(&pattern)
+    .fetch_all(&state.pool)
+    .await
+    .map_err(Into::into)
+}
+
+async fn search_nft_tokens(
+    state: &AppState,
+    query: &str,
+) -> Result<Vec<NftTokenResult>, atlas_common::AtlasError> {
+    let pattern = format!("%{}%", query);
+    sqlx::query_as(
+        "SELECT contract_address, token_id::text AS token_id, name, image_url
+         FROM nft_tokens
+         WHERE name ILIKE $1
+         ORDER BY last_transfer_block DESC NULLS LAST
+         LIMIT 5",
     )
     .bind(&pattern)
     .fetch_all(&state.pool)

--- a/backend/crates/atlas-server/src/api/handlers/search.rs
+++ b/backend/crates/atlas-server/src/api/handlers/search.rs
@@ -191,7 +191,10 @@ async fn search_block_by_number(
 }
 
 fn like_escape(input: &str) -> String {
-    input.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_")
+    input
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
 }
 
 async fn search_nft_collections(

--- a/backend/crates/atlas-server/src/api/handlers/search.rs
+++ b/backend/crates/atlas-server/src/api/handlers/search.rs
@@ -101,8 +101,9 @@ pub async fn search(
         }
     }
 
-    // Text search for tokens/collections if no hex/number results and query is meaningful
-    if results.is_empty() && query.len() >= 2 {
+    // Text search for tokens/collections if no hex/number results and query is long
+    // enough to benefit from the pg_trgm GIN indexes (trigrams require >= 3 chars).
+    if results.is_empty() && query.len() >= 3 {
         // Run NFT collection, NFT token, and ERC-20 searches in parallel
         let (nft_collection_results, nft_token_results, erc20_results) = tokio::join!(
             search_nft_collections(&state, query),
@@ -189,11 +190,15 @@ async fn search_block_by_number(
     .map_err(Into::into)
 }
 
+fn like_escape(input: &str) -> String {
+    input.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_")
+}
+
 async fn search_nft_collections(
     state: &AppState,
     query: &str,
 ) -> Result<Vec<NftContract>, atlas_common::AtlasError> {
-    let pattern = format!("%{}%", query);
+    let pattern = format!("%{}%", like_escape(query));
     sqlx::query_as(
         "SELECT address, name, symbol, total_supply, first_seen_block
          FROM nft_contracts
@@ -211,7 +216,7 @@ async fn search_nft_tokens(
     state: &AppState,
     query: &str,
 ) -> Result<Vec<NftTokenResult>, atlas_common::AtlasError> {
-    let pattern = format!("%{}%", query);
+    let pattern = format!("%{}%", like_escape(query));
     sqlx::query_as(
         "SELECT contract_address, token_id::text AS token_id, name, image_url
          FROM nft_tokens
@@ -229,7 +234,7 @@ async fn search_erc20_tokens(
     state: &AppState,
     query: &str,
 ) -> Result<Vec<Erc20Contract>, atlas_common::AtlasError> {
-    let pattern = format!("%{}%", query);
+    let pattern = format!("%{}%", like_escape(query));
     sqlx::query_as(
         "SELECT address, name, symbol, decimals, total_supply, first_seen_block
          FROM erc20_contracts

--- a/backend/migrations/20260424000001_nft_tokens_name_trgm.sql
+++ b/backend/migrations/20260424000001_nft_tokens_name_trgm.sql
@@ -1,0 +1,2 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX IF NOT EXISTS idx_nft_tokens_name_trgm ON nft_tokens USING GIN (name gin_trgm_ops) WHERE name IS NOT NULL;


### PR DESCRIPTION
## Summary
Extends the search API to query `nft_tokens.name` via `ILIKE`, returning up to 5 matching tokens as `nft`-typed results. Adds a GIN trigram index migration for fast name searches. The frontend already supports the `nft` result type end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NFT token search: discover NFT tokens by name alongside collections and ERC‑20 tokens.

* **Bug Fixes**
  * Text-search fallback now activates only for queries of three or more characters.
  * Wildcard query inputs are safely escaped to avoid unintended matches.

* **Chores**
  * Added a trigram index to improve NFT token name search performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->