### PR TITLE
fix: Indexing a fresh local chain from block 0 caused an integer underflow due to left-to-right evaluation.

### DIFF
--- a/backend/crates/atlas-server/src/indexer/indexer.rs
+++ b/backend/crates/atlas-server/src/indexer/indexer.rs
@@ -470,7 +470,7 @@ impl Indexer {
             let progress = (end_block as f64 / head as f64) * 100.0;
 
             tracing::info!(
-                start_block = end_block - batch_size as u64 + 1,
+                start_block = end_block + 1 - batch_size as u64,
                 end_block,
                 blocks = batch_size,
                 elapsed_secs = format_args!("{:.2}", elapsed.as_secs_f64()),


### PR DESCRIPTION
I was trying to test the indexer using a local chain on anvil. I ran into the following error:

```
2026-05-13T13:15:50.707433Z  INFO atlas_server::indexer::indexer: starting fetch workers workers=4 rpc_batch_size=20

thread 'tokio-rt-worker' (464933) panicked at crates/atlas-server/src/indexer/indexer.rs:473:31:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Steps to reproduce:
1. Set up .env for local test chain
```
DATABASE_URL=postgres://atlas:atlas@localhost:5432/atlas

RPC_URL=http://localhost:8545

CHAIN_NAME="Devnet"

everything else is defaults... 
```
2. `docker compose down -v`
3. `docker compose up -d postgres`
4. `anvil --host 127.0.0.1 --port 8545 --block-time 2       --chain-id 31337       --accounts 10 --balance 10000`
5. `just backend-run`

This would always throw the underflow error the first time I run. On running `just backend-run` a second time, it seems to start working as expected.

On the first run it looks like `end_block` is always equal to `batch_size - 1` causing an underflow due to it being subtracted before the `+ 1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code optimization with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evstack/atlas/pull/78)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->