### PR TITLE
fix: Correctly parse the limit/page pagination parameters when getting the logs emitted by a contract

### DIFF
--- a/backend/crates/atlas-server/src/api/handlers/logs.rs
+++ b/backend/crates/atlas-server/src/api/handlers/logs.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use crate::api::error::ApiResult;
 use crate::api::AppState;
-use atlas_common::{EventLog, PaginatedResponse, Pagination};
+use atlas_common::{EventLog, PaginatedResponse};
 
 /// Pagination for transaction log endpoints.
 #[derive(Debug, Deserialize)]
@@ -38,17 +38,19 @@ pub struct LogsQuery {
     /// Filter by event signature (topic0)
     pub topic0: Option<String>,
     /// Optional pagination
-    #[serde(flatten)]
-    pub pagination: Pagination,
+    #[serde(default = "default_page")]
+    pub page: u32,
+    #[serde(default = "default_limit")]
+    pub limit: u32,
 }
 
 impl LogsQuery {
     fn clamped_limit(&self) -> u32 {
-        self.pagination.limit.min(100)
+        self.limit.min(100)
     }
 
     fn offset(&self) -> i64 {
-        (self.pagination.page.saturating_sub(1) as i64) * self.clamped_limit() as i64
+        (self.page.saturating_sub(1) as i64) * self.clamped_limit() as i64
     }
 
     fn limit(&self) -> i64 {
@@ -147,7 +149,7 @@ pub async fn get_address_logs(
 
     Ok(Json(PaginatedResponse::new(
         logs,
-        query.pagination.page,
+        query.page,
         query.clamped_limit(),
         total,
     )))
@@ -253,6 +255,7 @@ fn normalize_address(address: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::LogsQuery;
     use super::TransactionLogsQuery;
     use atlas_common::PaginatedResponse;
 
@@ -271,5 +274,21 @@ mod tests {
             PaginatedResponse::new(Vec::<()>::new(), query.page, query.clamped_limit(), 250);
         assert_eq!(response.limit, 100);
         assert_eq!(response.total_pages, 3);
+    }
+
+    #[test]
+    fn logs_query_parses_pagination_from_query_string() {
+        use axum::extract::Query;
+        use axum::http::Uri;
+
+        let uri: Uri = "/?limit=20&page=2".parse().unwrap();
+        let Query(q): Query<LogsQuery> =
+            Query::try_from_uri(&uri).expect("Should be able to parse the query string");
+
+        assert_eq!(q.page, 2);
+        assert_eq!(q.limit, 20);
+
+        assert_eq!(q.limit(), 20);
+        assert_eq!(q.offset(), 20);
     }
 }


### PR DESCRIPTION
I set up a local chain through anvil and ran the atlas-server. I deployed a contract on the local chain and was trying to fetch the logs emitted by that contract with `curl -s "localhost:3000/api/addresses/0xe7f1725e7734ce288f8367e1bb143e90bb3f0512/logs?limit=20"`

Doing so triggered the following error:

```
$ curl -s "localhost:3000/api/addresses/0xe7f1725e7734ce288f8367e1bb143e90bb3f0512/logs?limit=20"
Failed to deserialize query string: invalid type: string "20", expected u32
```

It looks like the `#[serde(flatten)]` annotation on the `LogsQuery` doesn't play nicely with `axum::extract::Query`. The `flatten` attribute seems to keep the query parameters as strings internally, but the `LogsQuery` requires `u32`. 

I've removed the `Pagination` field and flattened it in line to match `TransactionLogsQuery`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated address logs endpoint to accept explicit `page` and `limit` query parameters for pagination.

* **Tests**
  * Extended test coverage for address logs query parameter parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evstack/atlas/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->